### PR TITLE
[ci] Test Coq 8.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.9"
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.10"
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.11"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.12"
 
 install:
 - docker pull ${DOCKERIMAGE}


### PR DESCRIPTION
CoqEAL compiles without change on Coq 8.12, so just adding it to the CI.
