### PR TITLE
Remove map2

### DIFF
--- a/refinements/multipoly.v
+++ b/refinements/multipoly.v
@@ -64,7 +64,8 @@ Definition mnmd_seq {n} (i : nat) (d : binnat.N) : seqmultinom :=
   nseq i 0%num ++ [:: d] ++ nseq (n - i - 1) 0%num.
 
 (** Multiplication of multinomials *)
-Definition mnm_add_seq (m1 m2 : seqmultinom) := map2 +%C m1 m2.
+Definition mnm_add_seq (m1 m2 : seqmultinom) :=
+  map (fun xy => xy.1 + xy.2)%C (zip m1 m2).
 
 Definition mdeg_eff : seqmultinom -> binnat.N := foldl +%C 0%C.
 
@@ -569,11 +570,12 @@ Proof.
 apply refines_abstr => mnm1 mnm1' ref_mnm1.
 apply refines_abstr => mnm2 mnm2' ref_mnm2.
 apply/refine_seqmultinomP.
-{ rewrite /mnm_add_seq size_map2.
+{ rewrite /mnm_add_seq size_map size_zip.
   by rewrite (@refine_size _ mnm1) (@refine_size _ mnm2) minnn. }
 move=> i.
-rewrite /mnm_add_seq (nth_map2 _ (da := 0%num) (db := 0%num)) //; last first.
-  by rewrite (@refine_size _ mnm1) (@refine_size _ mnm2).
+rewrite /mnm_add_seq (nth_map (0%num, 0%num)); last first.
+{ by rewrite size_zip (@refine_size _ mnm1) (@refine_size _ mnm2) minnn. }
+rewrite nth_zip /=; [|by rewrite (@refine_size _ mnm1) (@refine_size _ mnm2)].
 rewrite mnmDE -!refine_nth.
 exact: nat_of_add_bin.
 Qed.

--- a/theory/ssrcomplements.v
+++ b/theory/ssrcomplements.v
@@ -74,36 +74,6 @@ Qed.
 
 End Seqeqtype.
 
-(** ** map2 - Section taken from coq-interval *)
-Section Map2.
-Variables (A : Type) (B : Type) (C : Type).
-Variable f : A -> B -> C.
-
-Fixpoint map2 (s1 : seq A) (s2 : seq B) : seq C :=
-  match s1, s2 with
-    | a :: s3, b :: s4 => f a b :: map2 s3 s4
-    | _, _ => [::]
-  end.
-
-Lemma size_map2 (s1 : seq A) (s2 : seq B) :
-  size (map2 s1 s2) = minn (size s1) (size s2).
-Proof.
-elim: s1 s2 => [|x1 s1 IH1] [|x2 s2] //=.
-by rewrite IH1 -addn1 addn_minl 2!addn1.
-Qed.
-
-Lemma nth_map2 s1 s2 (k : nat) da db dc :
-  dc = f da db -> size s2 = size s1 ->
-  nth dc (map2 s1 s2) k = f (nth da s1 k) (nth db s2 k).
-Proof.
-elim: s1 s2 k => [|x1 s1 IH1] s2 k Habc Hsize.
-  by rewrite (size0nil Hsize) !nth_nil.
-case: s2 IH1 Hsize =>[//|x2 s2] IH1 [Hsize].
-case: k IH1 =>[//|k]; exact.
-Qed.
-
-End Map2.
-
 (******************** bigop.v ********************)
 Section BigOp.
 


### PR DESCRIPTION
It has been deemed in https://github.com/math-comp/math-comp/pull/755
to be redundant with map and zip. The performance impact is small.